### PR TITLE
Bug Fix

### DIFF
--- a/key-sender.js
+++ b/key-sender.js
@@ -112,7 +112,7 @@ module.exports = function() {
         return new Promise(function(resolve, reject) {
             var jarPath = path.join(__dirname, 'jar', 'key-sender.jar');
 
-            var command = 'java -jar ' + jarPath + ' ' + arrParams.join(' ') + module.getCommandLineOptions();
+            var command = 'java -jar \'' + jarPath + '\' ' + arrParams.join(' ') + module.getCommandLineOptions();
             console.log('Sending: ' + command);
 
             return exec(command, {}, function(error, stdout, stderr) {


### PR DESCRIPTION
The program does not work if there is free space in the package path before bug fix.
For example if my path is /path/to (1th)/package and i want to send left key then node-key-sender execute this command:
`java -jar /path/to (1th)/package left`
and this have an error.
I changed program to fix this bug.