### PR TITLE
Removed unnecessary and problematic console log

### DIFF
--- a/key-sender.js
+++ b/key-sender.js
@@ -113,7 +113,6 @@ module.exports = function() {
             var jarPath = path.join(__dirname, 'jar', 'key-sender.jar');
 
             var command = 'java -jar \'' + jarPath + '\' ' + arrParams.join(' ') + module.getCommandLineOptions();
-            console.log('Sending: ' + command);
 
             return exec(command, {}, function(error, stdout, stderr) {
                 if (error == null) {


### PR DESCRIPTION
This console log would be good if this program is CLI, but since it's a library, when a console log runs in my graphical app, it breaks it. I think, it's unnecessary.