### PR TITLE
Using app in Windows with space in filepath

### DIFF
--- a/key-sender.js
+++ b/key-sender.js
@@ -112,7 +112,7 @@ module.exports = function() {
         return new Promise(function(resolve, reject) {
             var jarPath = path.join(__dirname, 'jar', 'key-sender.jar');
 
-            var command = 'java -jar \'' + jarPath + '\' ' + arrParams.join(' ') + module.getCommandLineOptions();
+            var command = 'java -jar \"' + jarPath + '\" ' + arrParams.join(' ') + module.getCommandLineOptions();
 
             return exec(command, {}, function(error, stdout, stderr) {
                 if (error == null) {


### PR DESCRIPTION
As a comment mentioned in bug #3 replacing the escaped  single quote with double quotes solve this issue.