### PR TITLE
fix: Update command to fix incorrect path

### DIFF
--- a/key-sender.js
+++ b/key-sender.js
@@ -112,7 +112,7 @@ module.exports = function() {
         return new Promise(function(resolve, reject) {
             var jarPath = path.join(__dirname, 'jar', 'key-sender.jar');
 
-            var command = 'java -jar \"' + jarPath + '\" ' + arrParams.join(' ') + module.getCommandLineOptions();
+            var command = 'java -jar ' + jarPath + ' ' + arrParams.join(' ') + module.getCommandLineOptions();
 
             return exec(command, {}, function(error, stdout, stderr) {
                 if (error == null) {


### PR DESCRIPTION
* while execution due to single quote of script causing the issue of unable to access jarfile
Error: Unable to access jarfile 'F:\...\node_modules\nod
e-key-sender\jar\key-sender.jar'
this patch will fix the corresponding issue.

Tested on windows, working fine.